### PR TITLE
fix: normalize backend connection URL in affected admin modules

### DIFF
--- a/src/app/admin/BillingRequest/services/axiosInstance.ts
+++ b/src/app/admin/BillingRequest/services/axiosInstance.ts
@@ -1,13 +1,13 @@
 // src/app/admin/Billing/services/axiosInstance.ts
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
 /**
  * Usa NEXT_PUBLIC_API_URL para tu backend Nest (ej: http://localhost:3000)
  * Asegúrate de definirlo en tu .env.local:
  * NEXT_PUBLIC_API_URL=http://localhost:3000
  */
-export const API_URL =
-  process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ?? "http://localhost:3000";
+export const API_URL = resolveApiOrigin();
 
 const axiosInstance = axios.create({
   baseURL: API_URL, // Usando API_URL en lugar de baseURL

--- a/src/app/admin/BillingRequest/services/billing.api.ts
+++ b/src/app/admin/BillingRequest/services/billing.api.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import axios from "axios"; // para axios.isAxiosError
+import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin"; // para axios.isAxiosError
 import axiosInstance from "./axiosInstance";
 import type {
   CreatePaymentDto,
@@ -14,9 +15,7 @@ import { getSolicitud } from "../services/solicitudes.api";
    🔧 CONFIG GENERAL
 =========================================================== */
 
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL?.replace(/\/+$/, "") ??
-    "http://localhost:4000/api/") as string;
+export const API_URL = resolveApiOrigin();
 
 /** Headers automáticos con token localStorage si existe */
 function authHeader() {

--- a/src/app/admin/BillingRequest/services/solicitudes.api.ts
+++ b/src/app/admin/BillingRequest/services/solicitudes.api.ts
@@ -1,12 +1,12 @@
 "use client";
 
 import axiosInstance from "./axiosInstance";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
 /* =========================
  * Configuración base
  * ========================= */
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 function authHeader() {
   const t = typeof window !== "undefined" ? localStorage.getItem("token") : null;

--- a/src/app/admin/Collaborators/services/collaborators.api.ts
+++ b/src/app/admin/Collaborators/services/collaborators.api.ts
@@ -1,9 +1,9 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 function authHeader() {
   const t = typeof window !== "undefined" ? localStorage.getItem("token") : null;

--- a/src/app/admin/accounting/services/budget-service.ts
+++ b/src/app/admin/accounting/services/budget-service.ts
@@ -2,11 +2,11 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 import type { BudgetItem } from "../types";
 
 /* ========================= 🌐 Config base ========================= */
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 /* ========================= 🔐 Headers ========================= */
 function authHeader() {

--- a/src/app/admin/accounting/services/document-service.ts
+++ b/src/app/admin/accounting/services/document-service.ts
@@ -2,11 +2,11 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 import type { Document } from "../types";
 
 /* ========================= 🌐 Config base ========================= */
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 /* ========================= 🔐 Headers ========================= */
 function authHeader() {

--- a/src/app/admin/accounting/services/projects-service.ts
+++ b/src/app/admin/accounting/services/projects-service.ts
@@ -2,9 +2,9 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 export type ProjectOption = { id: number; title: string };
 

--- a/src/app/admin/accounting/services/transaction-service.ts
+++ b/src/app/admin/accounting/services/transaction-service.ts
@@ -2,11 +2,11 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 import type { Transaction } from "../types";
 
 /* ========================= 🌐 Config base ========================= */
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 /* ========================= 🔐 Headers ========================= */
 function authHeader() {

--- a/src/app/admin/comments/page.tsx
+++ b/src/app/admin/comments/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowLeft, MessageSquare, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
 type CommentStatus = "PENDIENTE" | "APROBADO" | "DENEGADO";
 
@@ -27,7 +28,7 @@ type CommentsResponse = {
   };
 };
 
-const API_BASE = `${process.env.NEXT_PUBLIC_API_URL}/api/comments`;
+const API_BASE = `${resolveApiOrigin()}/api/comments`;
 
 function getToken(): string | null {
   if (typeof window === "undefined") return null;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { DashboardMetrics } from "./components/DashboardMetrics";
 import { Button } from "@/components/ui/button";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
 type Role =
   | "admin"
@@ -77,7 +78,7 @@ export default function AdminDashboardPage() {
 
   async function loadPendingCommentsCount() {
     try {
-      const url = `${process.env.NEXT_PUBLIC_API_URL}/api/comments/admin/pending-count`;
+      const url = `${resolveApiOrigin()}/api/comments/admin/pending-count`;
 
       const res = await fetch(url, {
         cache: "no-store",
@@ -96,7 +97,7 @@ export default function AdminDashboardPage() {
 
   async function loadPendingRespuestasFormulariosCount() {
     try {
-      const url = `${process.env.NEXT_PUBLIC_API_URL}/api/respuestas-formulario/pending-count`;
+      const url = `${resolveApiOrigin()}/api/respuestas-formulario/pending-count`;
 
       const res = await fetch(url, {
         cache: "no-store",

--- a/src/app/admin/recapitulacion/services/report-service.ts
+++ b/src/app/admin/recapitulacion/services/report-service.ts
@@ -1,11 +1,11 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 import type { ReportData, SavedReport } from "../types/report";
 
 /* ========================= 🌐 Config base ========================= */
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 /* ========================= 🔐 Headers ========================= */
 function authHeader() {

--- a/src/app/admin/voluntariado/services/programaVoluntariadoService.ts
+++ b/src/app/admin/voluntariado/services/programaVoluntariadoService.ts
@@ -1,9 +1,9 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 /* ===================== 🔐 Headers ===================== */
 function authHeader() {

--- a/src/app/admin/voluntariado/services/sancionService.ts
+++ b/src/app/admin/voluntariado/services/sancionService.ts
@@ -1,10 +1,10 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 import type { Sancion, SancionCreateDTO, SancionUpdateDTO } from "../types/sancion";
 
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 function authHeader() {
   const t = typeof window !== "undefined" ? localStorage.getItem("token") : null;

--- a/src/app/admin/voluntariado/services/voluntarioService.ts
+++ b/src/app/admin/voluntariado/services/voluntarioService.ts
@@ -1,9 +1,9 @@
 "use client";
 
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
-export const API_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+export const API_URL = resolveApiOrigin();
 
 function authHeader() {
   const t = typeof window !== "undefined" ? localStorage.getItem("token") : null;

--- a/src/lib/api-origin.ts
+++ b/src/lib/api-origin.ts
@@ -1,0 +1,15 @@
+const FALLBACK_API_ORIGIN = "http://localhost:4000";
+
+export function resolveApiOrigin(): string {
+  const raw =
+    process.env.NEXT_PUBLIC_API_URL ||
+    process.env.NEXT_PUBLIC_API_BASE ||
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    FALLBACK_API_ORIGIN;
+
+  const trimmed = raw.replace(/\/+$/, "");
+  if (!trimmed) return FALLBACK_API_ORIGIN;
+
+  // Permite configurar NEXT_PUBLIC_API_URL con o sin sufijo /api
+  return trimmed.replace(/\/api$/i, "");
+}

--- a/src/services/respuestasFormulario.service.ts
+++ b/src/services/respuestasFormulario.service.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
+import { resolveApiOrigin } from "@/lib/api-origin";
 
-const BASE_URL =
-  (process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000").replace(/\/+$/, "");
+const BASE_URL = resolveApiOrigin();
 
 const API_URL = `${BASE_URL}/api`;
 


### PR DESCRIPTION
### Motivation
- Multiple admin modules were constructing backend endpoints directly from `NEXT_PUBLIC_API_URL` which could be missing or include a trailing `/api`, producing malformed requests (e.g. `/api/api/...`) in some deployments.
- The change aims to standardize how the application resolves the backend origin so all modules build correct URLs without touching business logic, UI or behavior.

### Description
- Added a shared helper `resolveApiOrigin()` in `src/lib/api-origin.ts` to centralize backend origin resolution and normalize trailing slashes and an optional `/api` suffix.
- Replaced direct uses of `process.env.NEXT_PUBLIC_API_URL` / hardcoded fallbacks with `resolveApiOrigin()` in affected files so `API_URL` or `BASE_URL` are computed from the normalized origin.
- Updated admin modules that reported connectivity issues (Voluntariado, Solicitudes/Facturación, Colaboradores, Contabilidad, Recapitulación, Comentarios and Respuestas de Formularios) to use the helper; endpoints themselves remain unchanged.
- Files modified include (not exhaustive): `src/lib/api-origin.ts`, `src/app/admin/voluntariado/services/*`, `src/app/admin/BillingRequest/services/*`, `src/app/admin/Collaborators/services/collaborators.api.ts`, `src/app/admin/accounting/services/*`, `src/app/admin/recapitulacion/services/report-service.ts`, `src/app/admin/comments/page.tsx`, `src/app/admin/page.tsx`, and `src/services/respuestasFormulario.service.ts`.

### Testing
- Ran `npm run lint` to validate edits and ensure no syntax issues from the change, and the command executed (the linter reported many preexisting TypeScript/ESLint errors across the repo that are unrelated to these connectivity edits).
- No runtime changes or functional tests were modified, and the edits are limited to how the base origin is resolved so manual verification in the target deployment environment is recommended (set `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_API_BASE` as appropriate).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2d9579ed483298f240df8391e0e2f)